### PR TITLE
feat(site): sites outdoors+template de produits associés  

### DIFF
--- a/backend/pc-tarn-logistique-api/src/modules/site/dto/create-site.dto.ts
+++ b/backend/pc-tarn-logistique-api/src/modules/site/dto/create-site.dto.ts
@@ -4,6 +4,10 @@ import { Type } from 'class-transformer';
 import { IsEnum, IsNotEmpty, IsOptional, IsString, ValidateNested } from 'class-validator';
 import { CreateAddressDto } from '../../../shared/dto/create-address.dto';
 
+/**
+ * DTO utilise pour creer un site.
+ * Il transporte les informations d'identification du site et son adresse eventuelle.
+ */
 export class CreateSiteDto {
     @ApiProperty({ description: 'Nom du site', example: "Antenne d'Albi" })
     @IsString()
@@ -29,7 +33,6 @@ export class CreateSiteDto {
         required: false,
         type: CreateAddressDto,
     })
-
     @ValidateNested()
     @Type(() => CreateAddressDto)
     @IsOptional()

--- a/backend/pc-tarn-logistique-api/src/modules/site/dto/update-site.dto.ts
+++ b/backend/pc-tarn-logistique-api/src/modules/site/dto/update-site.dto.ts
@@ -1,4 +1,8 @@
 import { PartialType } from '@nestjs/swagger';
 import { CreateSiteDto } from './create-site.dto';
 
+/**
+ * DTO utilise pour mettre a jour un site.
+ * Toutes les proprietes de creation y deviennent optionnelles.
+ */
 export class UpdateSiteDto extends PartialType(CreateSiteDto) {}

--- a/backend/pc-tarn-logistique-api/src/modules/site/entities/site.entity.ts
+++ b/backend/pc-tarn-logistique-api/src/modules/site/entities/site.entity.ts
@@ -1,7 +1,11 @@
-import { BagTemplateEntity } from '../../bag/bag-template/entities/bag-template.entity';
-import { Site, SiteType } from '@prisma/client';
 import { ApiProperty } from '@nestjs/swagger';
+import { Site, SiteType } from '@prisma/client';
+import { BagTemplateEntity } from '../../bag/bag-template/entities/bag-template.entity';
 
+/**
+ * Entite de sortie representant un site expose par l'API.
+ * Elle peut embarquer le modele de sac theorique et l'adresse associee.
+ */
 export class SiteEntity implements Site {
     @ApiProperty({ description: 'Identifiant unique du site', example: 1 })
     id: number;
@@ -19,19 +23,17 @@ export class SiteEntity implements Site {
     @ApiProperty({ description: 'Code unique du site', example: 'ALB' })
     code: string;
 
-    // 1ère CORRECTION : On autorise le "null" car un site INDOOR n'a pas de sac
     @ApiProperty({
         required: false,
         nullable: true,
-        description: 'ID du modèle de sac si le site est de type OUTDOOR',
+        description: 'Identifiant du modele de sac si le site est de type OUTDOOR',
     })
     bagTemplateId: number | null;
 
-    // 2ème CORRECTION : On ajoute l'objet complet bagTemplate pour le service
     @ApiProperty({
         required: false,
         type: () => BagTemplateEntity,
-        description: 'Le modèle théorique du sac lié à ce site',
+        description: 'Le modele theorique du sac lie a ce site',
     })
     bagTemplate?: BagTemplateEntity;
 
@@ -51,6 +53,10 @@ export class SiteEntity implements Site {
         siteId: number | null;
     } | null;
 
+    /**
+     * Construit une entite a partir d'un objet partiel.
+     * @param partial Donnees a affecter a l'entite.
+     */
     constructor(partial: Partial<SiteEntity>) {
         Object.assign(this, partial);
     }

--- a/backend/pc-tarn-logistique-api/src/modules/site/site.controller.ts
+++ b/backend/pc-tarn-logistique-api/src/modules/site/site.controller.ts
@@ -4,12 +4,16 @@ import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagg
 import { Roles } from '../../core/decorators/roles.decorator';
 import { RolesGuard } from '../../core/guards/roles.guard';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
-import { SiteService } from './site.service';
+import { ProductEntity } from '../products/entities/product.entity';
 import { CreateSiteDto } from './dto/create-site.dto';
 import { UpdateSiteDto } from './dto/update-site.dto';
 import { SiteEntity } from './entities/site.entity';
-import { BagTemplateItemEntity } from '../bag/bag-template-item/entities/bag-template-item.entity';
+import { SiteService } from './site.service';
 
+/**
+ * Controleur REST dedie a la gestion des sites logistiques.
+ * Il expose les operations CRUD ainsi que les routes specifiques aux sites outdoor.
+ */
 @ApiTags('Sites')
 @ApiBearerAuth()
 @UseGuards(JwtAuthGuard, RolesGuard)
@@ -17,6 +21,11 @@ import { BagTemplateItemEntity } from '../bag/bag-template-item/entities/bag-tem
 export class SiteController {
     constructor(private readonly siteService: SiteService) {}
 
+    /**
+     * Cree un nouveau site.
+     * Cette operation est reservee aux administrateurs et aux managers.
+     * @param createSiteDto Donnees de creation du site.
+     */
     @Post()
     @Roles(Role.ADMIN, Role.MANAGER)
     @ApiOperation({ summary: 'Creer un site' })
@@ -24,28 +33,42 @@ export class SiteController {
     create(@Body() createSiteDto: CreateSiteDto) {
         return this.siteService.create(createSiteDto);
     }
-    
+
+    /**
+     * Recupere la liste de tous les sites.
+     */
     @Get()
     @ApiOperation({ summary: 'Recuperer la liste de tous les sites' })
     @ApiResponse({ type: [SiteEntity], status: 200 })
     findAll() {
         return this.siteService.findAll();
     }
-    
-    @Get('outdoors')
-    @ApiOperation({ summary: 'Recuperer tous les sites outdoors(bags)' })
-    @ApiResponse({ type: SiteEntity, status: 200 })
-    FindOutDoors() {
-        return this.siteService.findAllOutDoors();
-    }
 
+    /**
+     * Recupere les produits attendus dans le sac theorique d'un site outdoor.
+     * @param id Identifiant du site outdoor.
+     */
     @Get('outdoors/:id/bag-items')
-    @ApiOperation({ summary: 'Recuperer les produits attendus dans un site OUTDOOR' })
-    @ApiResponse({ type: BagTemplateItemEntity, status: 200 })
+    @ApiOperation({ summary: 'Recuperer les produits attendus pour un site outdoor' })
+    @ApiResponse({ type: [ProductEntity], status: 200 })
     findBagItems(@Param('id', ParseIntPipe) id: number) {
         return this.siteService.findAllExpectedOutdoorItems(id);
     }
 
+    /**
+     * Recupere la liste des sites outdoor avec leur dernier controle de sac.
+     */
+    @Get('outdoors')
+    @ApiOperation({ summary: 'Recuperer tous les sites outdoor' })
+    @ApiResponse({ type: [SiteEntity], status: 200 })
+    findAllOutDoors() {
+        return this.siteService.findAllOutDoors();
+    }
+
+    /**
+     * Recupere un site par son identifiant.
+     * @param id Identifiant du site recherche.
+     */
     @Get(':id')
     @ApiOperation({ summary: 'Recuperer un site par son ID' })
     @ApiResponse({ type: SiteEntity, status: 200 })
@@ -53,8 +76,12 @@ export class SiteController {
         return this.siteService.findOne(id);
     }
 
-    
-
+    /**
+     * Met a jour un site existant.
+     * Cette operation est reservee aux administrateurs et aux managers.
+     * @param id Identifiant du site a modifier.
+     * @param updateSiteDto Donnees de mise a jour.
+     */
     @Patch(':id')
     @Roles(Role.ADMIN, Role.MANAGER)
     @ApiOperation({ summary: 'Mettre a jour un site par son ID' })
@@ -63,6 +90,11 @@ export class SiteController {
         return this.siteService.update(id, updateSiteDto);
     }
 
+    /**
+     * Supprime un site par son identifiant.
+     * Cette operation est reservee aux administrateurs et aux managers.
+     * @param id Identifiant du site a supprimer.
+     */
     @Delete(':id')
     @Roles(Role.ADMIN, Role.MANAGER)
     @ApiOperation({ summary: 'Supprimer un site par son ID' })

--- a/backend/pc-tarn-logistique-api/src/modules/site/site.module.ts
+++ b/backend/pc-tarn-logistique-api/src/modules/site/site.module.ts
@@ -1,8 +1,12 @@
 import { Module } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
-import { SiteService } from './site.service';
 import { SiteController } from './site.controller';
+import { SiteService } from './site.service';
 
+/**
+ * Module NestJS dedie a la gestion des sites.
+ * Il assemble le controleur, le service et l'acces a Prisma.
+ */
 @Module({
     controllers: [SiteController],
     providers: [SiteService, PrismaService],

--- a/backend/pc-tarn-logistique-api/src/modules/site/site.service.spec.ts
+++ b/backend/pc-tarn-logistique-api/src/modules/site/site.service.spec.ts
@@ -124,6 +124,7 @@ describe('SiteService', () => {
                     address: true,
                     bagChecks: {
                         orderBy: { date: 'desc' },
+                        take: 1,
                     },
                 },
                 orderBy: { id: 'asc' },

--- a/backend/pc-tarn-logistique-api/src/modules/site/site.service.ts
+++ b/backend/pc-tarn-logistique-api/src/modules/site/site.service.ts
@@ -4,22 +4,28 @@ import { PrismaService } from '../../prisma/prisma.service';
 import { CreateSiteDto } from './dto/create-site.dto';
 import { UpdateSiteDto } from './dto/update-site.dto';
 import { SiteEntity } from './entities/site.entity';
-import { BagTemplateSiteService } from '../bag/bag-template-site/bag-template-site.service';
-import { json } from 'stream/consumers';
 
 const siteRelations = {
     address: true,
-    bagChecks:true,
+    bagChecks: true,
 } satisfies Prisma.SiteInclude;
 
 type SiteWithRelations = Prisma.SiteGetPayload<{
     include: typeof siteRelations;
 }>;
 
+/**
+ * Service metier charge de la gestion des sites.
+ * Il centralise les acces Prisma et la transformation des resultats en entites API.
+ */
 @Injectable()
 export class SiteService {
     constructor(private readonly prisma: PrismaService) {}
 
+    /**
+     * Cree un site et son adresse eventuelle.
+     * @param dto Donnees de creation du site.
+     */
     async create(dto: CreateSiteDto) {
         const site = await this.prisma.site.create({
             data: this.buildCreateData(dto),
@@ -29,6 +35,9 @@ export class SiteService {
         return this.toEntity(site);
     }
 
+    /**
+     * Recupere tous les sites avec leurs relations utiles.
+     */
     async findAll() {
         const sites = await this.prisma.site.findMany({
             include: siteRelations,
@@ -38,45 +47,84 @@ export class SiteService {
         return sites.map((site) => this.toEntity(site));
     }
 
+    /**
+     * Recupere tous les sites outdoor avec leur dernier controle de sac.
+     */
     async findAllOutDoors() {
         const sites = await this.prisma.site.findMany({
-            where: { type: SiteType.OUTDOOR},
+            where: { type: SiteType.OUTDOOR },
             include: {
-                address:true,
-                bagChecks:{
-                    orderBy:{date: 'desc'}
-                }
+                address: true,
+                bagChecks: {
+                    orderBy: { date: 'desc' },
+                    take: 1, // On conserve uniquement le dernier bagCheck de chaque site outdoor.
+                },
             },
-            orderBy: { id: 'asc' }
+            orderBy: { id: 'asc' },
         });
 
         return sites.map((site) => this.toEntity(site));
     }
-    
-    async findAllExpectedOutdoorItems(id:number){
-        const bagTemplateSite = this.prisma.bagTemplateSite.findFirst(
-            {
-                where:{
-                    siteId:id
-                }
-            }
 
-        )
-        return bagTemplateSite
+    /**
+     * Recupere les produits attendus pour un site outdoor a partir de son modele de sac.
+     * @param id Identifiant du site outdoor.
+     */
+    async findAllExpectedOutdoorItems(id: number) {
+        const site = await this.prisma.site.findUnique({
+            where: { id },
+            select: {
+                bagTemplateSite: {
+                    select: {
+                        bagTemplate: {
+                            select: {
+                                items: {
+                                    select: {
+                                        product: true,
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        });
+
+        if (!site) {
+            throw new NotFoundException(`Site #${id} introuvable`);
+        }
+
+        // On aplatit les produits du modele template dans un tableau simple.
+        const products = site.bagTemplateSite?.bagTemplate?.items.map((item) => item.product) ?? [];
+        if (products.length === 0) {
+            throw new NotFoundException(`Aucun produit template n'a ete trouve pour le site #${id}`);
+        }
+
+        return products;
     }
+
+    /**
+     * Recupere un site par son identifiant.
+     * @param id Identifiant du site recherche.
+     */
     async findOne(id: number) {
         const site = await this.prisma.site.findUnique({
             where: { id },
             include: siteRelations,
         });
 
-        if (!site) throw new NotFoundException(`Site #${id} not found`);
+        if (!site) throw new NotFoundException(`Site #${id} introuvable`);
 
         return this.toEntity(site);
     }
 
+    /**
+     * Met a jour un site apres verification de son existence.
+     * @param id Identifiant du site a modifier.
+     * @param dto Donnees de mise a jour.
+     */
     async update(id: number, dto: UpdateSiteDto) {
-        await this.findOne(id); // ensure exists
+        await this.findOne(id); // On verifie d'abord que le site existe.
 
         const site = await this.prisma.site.update({
             where: { id },
@@ -87,8 +135,12 @@ export class SiteService {
         return this.toEntity(site);
     }
 
+    /**
+     * Supprime un site apres verification de son existence.
+     * @param id Identifiant du site a supprimer.
+     */
     async remove(id: number) {
-        await this.findOne(id); // ensure exists
+        await this.findOne(id); // On verifie d'abord que le site existe.
 
         const site = await this.prisma.site.delete({
             where: { id },
@@ -98,10 +150,10 @@ export class SiteService {
         return this.toEntity(site);
     }
 
-    // ---------------------------
-    // PRIVATE HELPERS
-    // ---------------------------
-
+    /**
+     * Construit les donnees Prisma necessaires a la creation d'un site.
+     * @param dto Donnees entrantes du site.
+     */
     private buildCreateData(dto: CreateSiteDto): Prisma.SiteCreateInput {
         const { address, ...siteData } = dto;
 
@@ -111,8 +163,12 @@ export class SiteService {
         };
     }
 
+    /**
+     * Construit les donnees Prisma necessaires a la mise a jour d'un site.
+     * @param dto Donnees de mise a jour du site.
+     */
     private buildUpdateData(dto: UpdateSiteDto): Prisma.SiteUpdateInput {
-        const { address,...siteData } = dto;
+        const { address, ...siteData } = dto;
 
         return {
             ...siteData,
@@ -120,10 +176,14 @@ export class SiteService {
         };
     }
 
+    /**
+     * Transforme un resultat Prisma en entite API.
+     * @param site Site charge avec ses relations.
+     */
     private toEntity(site: SiteWithRelations) {
         return new SiteEntity({
             ...site,
-            // On convertit les 'null' de Prisma en 'undefined' pour TypeScript
+            // On convertit les valeurs null de Prisma en undefined pour TypeScript.
             address: site.address ?? undefined,
         });
     }


### PR DESCRIPTION
- endpoint : sites/outdoors/:id/bag-items ☑️ disponible
  - renvoie le template de produits associés au sac (site outdoor)
- ajouter la recuperation des produits attendus via le bag template d'un site outdoor
- limiter la remontee des sites outdoor au dernier bagCheck
- traduire les messages, commentaires et descriptions Swagger du module site en francais
- ajouter les docstrings manquantes dans le service, le controleur, le module, les DTO et l'entite